### PR TITLE
Fix macro definitions in timing.h

### DIFF
--- a/boards/shields/quacken/timing.h
+++ b/boards/shields/quacken/timing.h
@@ -29,8 +29,8 @@
 #define TAPPING_TERM 300
 #endif
 
-#define EZ_SL(layer) bsl (layer) (layer)
-#define EZ_SK(mod)   bsk (mod) (mod)
+#define EZ_SL(layer) &bsl (layer) (layer)
+#define EZ_SK(mod)   &bsk (mod) (mod)
 &sl{ quick-release; }; // seems useless (works fine without)
 &sk{ quick-release; }; // must have (lots of false positives otherwise)
 


### PR DESCRIPTION
Ajout de "&" dans les définitions